### PR TITLE
chore: 升级依赖版本

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.1-SNAPSHOT</version>
+        <version>3.5.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.situ</groupId>
@@ -14,8 +14,8 @@
     <name>JsonResourceAnnotation</name>
     <description>an annotation for json resource import</description>
     <properties>
-        <java.version>1.8</java.version>
-        <fastjson.vsersion>1.2.62</fastjson.vsersion>
+        <java.version>17</java.version>
+        <fastjson.vsersion>1.2.83</fastjson.vsersion>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
升级以下依赖版本：
- Spring Boot 从旧版本升级到 3.5.0，以获取新功能和安全补丁。
- FastJSON 从旧版本升级到 1.2.83，修复已知漏洞。
- jdk 到 17